### PR TITLE
Added cookie banner

### DIFF
--- a/challenges/challenges/settings.py
+++ b/challenges/challenges/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 
 import os
 from pathlib import Path
+from django.utils.translation import gettext_lazy as _
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -42,6 +43,7 @@ INSTALLED_APPS = [
     # "tailwind",
     # "theme",
     "django_browser_reload",
+    "cookiebanner"
 ]
 
 MIDDLEWARE = [
@@ -133,3 +135,30 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 INTERNAL_IPS = [
     "127.0.0.1",
 ]
+
+COOKIEBANNER = {
+    "title": _("Cookie settings"),
+    "header_text": _("We are using cookies on this website. We only use essential cookies to keep this site safe and functional."),  # This must ALWAYS remain true!!!
+    "footer_text": _("Please accept our cookies. The website doesn't function without them."),
+    "groups": [
+        {
+            "id": "essential",
+            "name": _("Essential"),
+            "description": _("Essential cookies allow this page to work."),
+            "cookies": [
+                {
+                    "pattern": "cookiebanner",
+                    "description": _("Meta cookie for the cookies that are set."),
+                },
+                {
+                    "pattern": "csrftoken",
+                    "description": _("This cookie prevents Cross-Site-Request-Forgery attacks."),
+                },
+                {
+                    "pattern": "sessionid",
+                    "description": _("This cookie is necessary to allow logging in, for example."),
+                },
+            ],
+        }
+    ],
+}

--- a/challenges/challenges_app/templates/layout.html
+++ b/challenges/challenges_app/templates/layout.html
@@ -1,47 +1,58 @@
 {% load static %}
+{% load cookiebanner %}
 
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link href="{% static 'styles.css' %}" rel="stylesheet">
-        <link href="{% static 'pygment.css' %}" rel="stylesheet">
-        <link href="{% static 'tailwind.css' %}" rel="stylesheet">
-        <title>{%block title %}{% endblock %}</title>
-        {% block head %}{% endblock %}
-    </head>
-    <body class="dark:bg-black">
-        <nav>
-            <span class="inline-flex -space-x-px overflow-hidden rounded-md border bg-white shadow-sm">
-                <button class="inline-block px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:relative">
-                    <a href="{% url 'index' %}">Index</a>
-                </button>
-                {% if user.is_authenticated %}
-                    <button class="inline-block px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:relative">
-                        <a href="{% url 'account' %}">Account</a>
-                    </button>
-                    <button class="inline-block px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:relative">
-                        <a href="{% url 'logout' %}">Logout</a>
-                    </button>
-                {% else %}
-                    <button class="inline-block px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:relative">
-                        <a href="{% url 'login' %}">Login</a>
-                    </button>
-                    <button class="inline-block px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:relative">
-                        <a href="{% url 'signup' %}">Sign Up</a>
-                    </button>
-                {% endif %}
-            </span>
-            {% block nav %}
-            {% endblock %}
-        </nav>
-        {% if message %}
-            <div>{{ message }}</div>
-        {% endif %}
-        <div class="main">
-            {% block body %}
-            {% endblock %}
-        </div>
-    </body>
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0">
+    <link href="{% static 'styles.css' %}"
+          rel="stylesheet">
+    <link href="{% static 'pygment.css' %}"
+          rel="stylesheet">
+    <link href="{% static 'tailwind.css' %}"
+          rel="stylesheet">
+    <title>{%block title %}{% endblock %}</title>
+    {% block head %}{% endblock %}
+</head>
+
+<body class="dark:bg-black">
+    {% cookiebanner_modal 'vanilla' %}
+    <nav>
+        <span class="inline-flex -space-x-px overflow-hidden rounded-md border bg-white shadow-sm">
+            <button class="inline-block px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:relative">
+                <a href="{% url 'index' %}">Index</a>
+            </button>
+            {% if user.is_authenticated %}
+            <button class="inline-block px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:relative">
+                <a href="{% url 'account' %}">Account</a>
+            </button>
+            <button class="inline-block px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:relative">
+                <a href="{% url 'logout' %}">Logout</a>
+            </button>
+            {% else %}
+            <button class="inline-block px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:relative">
+                <a href="{% url 'login' %}">Login</a>
+            </button>
+            <button class="inline-block px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:relative">
+                <a href="{% url 'signup' %}">Sign Up</a>
+            </button>
+            {% endif %}
+        </span>
+        {% block nav %}
+        {% endblock %}
+    </nav>
+    {% if message %}
+    <div>{{ message }}</div>
+    {% endif %}
+    <div class="main">
+        {% block body %}
+        {% endblock %}
+    </div>
+    <button onclick="document.querySelector('#cookiebannerModal').classList.remove('hidden')">Change cookie
+        preferences</button>
+</body>
+
 </html>

--- a/challenges/settings.py
+++ b/challenges/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "challenges_app",
     "django_browser_reload",
+    "cookiebanner",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
Added the [django-cookiebanner](https://pypi.org/project/django-cookiebanner/) module to notify users of cookie usage for GDRP compliance. It is not possible to refuse any of our current cookies. We can add functions to refuse cookies, but we shouldn't need to as we're only using essential cookies and we should not stray from that unless absolutely impossible.